### PR TITLE
Add missing environment specific block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Middleman's [environment specific settings][ess], for example:
 
 ```ruby
 # config.rb
-configure :development do |d|
+configure :development do
   activate :disqus do |d|
     # using a special shortname
     d.shortname = "development-shortname"


### PR DESCRIPTION
Without specifying development block, disqus settings for build are ignored as duplicated.
