### PR TITLE
Added per call options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in middleman-google-analytics.gemspec
+# Specify your gem's dependencies in middleman-disqus.gemspec
 gemspec
 
 group :development do

--- a/features/disqus.feature
+++ b/features/disqus.feature
@@ -68,3 +68,31 @@ Feature: Disqus Integration
     And the file "options.html" should not contain "var disqus_url"
     And the file "options.html" should contain "var disqus_category_id = 4;"
     And the file "options.html" should contain "var disqus_disable_mobile = false;"
+
+  Scenario: Per call Disqus variables
+    Given a fixture app "disqus-app"
+    And a file named "source/per-call-options.html.erb" with:
+      """
+      <%= disqus disqus_url: "http://example.com/2012/the-best-day-of-my-life.html" %>
+      """
+    And a successfully built app at "disqus-app"
+    When I cd to "build"
+    Then the following files should exist:
+      | per-call-options.html |
+    And the file "per-call-options.html" should contain "var disqus_url = 'http://example.com/2012/the-best-day-of-my-life.html';"
+
+  Scenario: Per call Disqus variables overriding page variables
+    Given a fixture app "disqus-app"
+    And a file named "source/per-call-options.html.erb" with:
+      """
+      ---
+      disqus_identifier: /2012/the-best-day-of-my-life.html
+      disqus_url: http://example.com/2012/better-day-of-my-life.html
+      ---
+      <%= disqus disqus_url: "http://example.com/2012/the-best-day-of-my-life.html" %>
+      """
+    And a successfully built app at "disqus-app"
+    When I cd to "build"
+    Then the following files should exist:
+      | per-call-options.html |
+    And the file "per-call-options.html" should contain "var disqus_url = 'http://example.com/2012/the-best-day-of-my-life.html';"

--- a/lib/middleman-disqus/extension.rb
+++ b/lib/middleman-disqus/extension.rb
@@ -19,7 +19,7 @@ module Middleman
     end
 
     helpers do
-      def disqus(call_options)
+      def disqus(call_options = {})
         page_options = current_resource.metadata[:page].merge(call_options)
         @options = Middleman::DisqusExtension.options(page_options)
         return '' unless @options[:shortname]

--- a/lib/middleman-disqus/extension.rb
+++ b/lib/middleman-disqus/extension.rb
@@ -19,8 +19,8 @@ module Middleman
     end
 
     helpers do
-      def disqus
-        page_options = current_resource.metadata[:page]
+      def disqus(call_options)
+        page_options = current_resource.metadata[:page].merge(call_options)
         @options = Middleman::DisqusExtension.options(page_options)
         return '' unless @options[:shortname]
 

--- a/lib/middleman-disqus/version.rb
+++ b/lib/middleman-disqus/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module Disqus
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end


### PR DESCRIPTION
Hi. I'd like to add a possibility to add options when using `disqus` helper in your layout/page. Why setting options during the call instead in the frontmatter of the page? Because Middleman is all about automating tedious tasks that can be automated. :) 
A useful case is constructing `disqus_url` parameter from the global project’s site-url (project setting) and page-specific `disqus_identifier` set in frontmatter. Not setting the `disqus_url` can [spoil your production's server topic-url, if you preview your build locally on development machine](https://help.disqus.com/customer/portal/articles/735138-why-are-the-wrong-urls-detected-for-my-discussions-) so we should set both parameters on every page, like this:

```
---
disqus_identifier: /2012/the-best-day-of-my-life.html
disqus_url: http://example.com/2012/the-best-day-of-my-life.html
---
```

While Middleman evaluates current page, we already know the final URL for that page, thus constructing `disqus_url` can be automated, which reduces clutter in frontmatter and removes one possibility of mistake. It can be constructed in the article-template and used when calling the `disqus` helper. So, after removing the `disqus_url` from the frontmatter, my `article-layout.erb` file has:

```
<div id="comments">
  <%= disqus disqus_url: ("http://example.com" + current_page.url) %>
</div>
```

Question: currently options passed to helper call will override options set in frontmatter. Maybe this should be opposite? Then frontmatter would override the page-template code.

Guys, my code change is relatively simple, and I've added 2 tests, but please review this, since I don't have much experience in digging Rails-type infrastructure, using Cucumber etc. Thanks! Bumped the version number, I hope this is correct.

BTW, I've corrected one comment left from middleman-google-analytics code.